### PR TITLE
Add connection retry logic for Red Pitaya WiFi sketches

### DIFF
--- a/AcquireNowWifi/AcquireNowWifi.ino
+++ b/AcquireNowWifi/AcquireNowWifi.ino
@@ -1,60 +1,48 @@
 /* UNO R4 WiFi → Red Pitaya (SCPI)
    acquire_full_buffer_raw: force trigger and read full buffer as RAW ASCII codes
 */
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"
 
 IPAddress RP_IP(192,168,0,17);
 const uint16_t RP_PORT = 5000;
 
-WiFiClient client;
+WifiSCPI rp;
 
-/* helpers */
-void scpiFlush(){ while(client.available()) (void)client.read(); }
-inline void scpi(const String& s){ client.print(s); client.print("\r\n"); }
-String scpiLine(const String& s, unsigned long to=3000){
-  scpiFlush(); scpi(s); String r; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(c=='\n'){ if(r.endsWith("\r")) r.remove(r.length()-1); return r; } r+=c; }
-  return r;
-}
-String scpiBlock(const String& s, unsigned long to=10000){
-  scpiFlush(); scpi(s); String r; bool in=false; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(!in){ if(c=='{'){ in=true; r+=c; } continue; } r+=c; if(c=='}') return r; }
-  return r;
-}
 void printFirst(const String& blk, uint8_t n=12){
-  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
-  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First RAW samples:"));
-  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
-    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}');
+  if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r);
+  int st=0,c=0;
+  Serial.println(F("First RAW samples:"));
+  while(c<n){
+    int k=b.indexOf(',',st);
+    String t=(k==-1)?b.substring(st):b.substring(st,k);
+    t.trim();
+    if(t.length()){ Serial.println(t); c++; }
+    if(k==-1) break;
+    st=k+1;
+  }
 }
-bool connectWiFi(unsigned long to=30000){
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0=millis(); while(WiFi.status()!=WL_CONNECTED && millis()-t0<to) delay(250);
-  if(WiFi.status()!=WL_CONNECTED) return false;
-  unsigned long t1=millis(); while(WiFi.localIP()==IPAddress(0,0,0,0)&&millis()-t1<3000) delay(50);
-  return true;
-}
-bool connectRP(){ if(client.connected()) return true; client.stop(); return client.connect(RP_IP, RP_PORT); }
 
 void setup(){
-  Serial.begin(115200); delay(200);
-  connectWiFi(); connectRP();
+  Serial.begin(115200);
+  delay(200);
+  rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT);
 
-  scpi("ACQ:RST");
-  scpi("ACQ:DEC:Factor 1");
-  scpi("ACQ:DATA:FORMAT ASCII");
-  scpi("ACQ:DATA:UNITS RAW");   // ADC codes
-  scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT ASCII");
+  rp.scpi("ACQ:DATA:UNITS RAW");   // ADC codes
+  rp.scpi("ACQ:TRig:DLY 0");
 
-  scpi("ACQ:START");
+  rp.scpi("ACQ:START");
   delay(300);
-  scpi("ACQ:TRig NOW");
+  rp.scpi("ACQ:TRig NOW");
 
-  while(scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
-  printFirst(scpiBlock("ACQ:SOUR1:DATA?"));
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
   Serial.println("Done.");
 }
-void loop(){ }
+
+void loop(){}

--- a/wifiSCPI.cpp
+++ b/wifiSCPI.cpp
@@ -1,0 +1,81 @@
+#include "wifiSCPI.h"
+
+WifiSCPI::WifiSCPI() : _client() {}
+
+bool WifiSCPI::begin(const char* ssid, const char* pass, const IPAddress& ip, uint16_t port){
+  while(!connectWiFi(ssid, pass)) {
+    Serial.println(F("WiFi not ready, retrying..."));
+    delay(1000);
+  }
+  while(!connectRP(ip, port)) {
+    Serial.println(F("SCPI connection failed, retrying..."));
+    delay(1000);
+  }
+  return true;
+}
+
+bool WifiSCPI::connectWiFi(const char* ssid, const char* pass, unsigned long timeout){
+  WiFi.begin(ssid, pass);
+  unsigned long t0 = millis();
+  while(WiFi.status() != WL_CONNECTED && millis() - t0 < timeout) delay(250);
+  if(WiFi.status() != WL_CONNECTED) return false;
+  unsigned long t1 = millis();
+  while(WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
+  return true;
+}
+
+bool WifiSCPI::connectRP(const IPAddress& ip, uint16_t port){
+  if(_client.connected()) return true;
+  _client.stop();
+  return _client.connect(ip, port);
+}
+
+void WifiSCPI::scpiFlush(){
+  while(_client.available()) (void)_client.read();
+}
+
+void WifiSCPI::scpi(const String& s){
+  _client.print(s);
+  _client.print("\r\n");
+}
+
+String WifiSCPI::scpiLine(const String& s, unsigned long timeout){
+  scpiFlush();
+  scpi(s);
+  String r;
+  unsigned long t0 = millis();
+  while(millis() - t0 < timeout) {
+    while(_client.available()) {
+      char c = _client.read();
+      if(c == '\n') {
+        if(r.endsWith("\r")) r.remove(r.length()-1);
+        return r;
+      }
+      r += c;
+    }
+  }
+  return r;
+}
+
+String WifiSCPI::scpiBlock(const String& s, unsigned long timeout){
+  scpiFlush();
+  scpi(s);
+  String r;
+  bool in = false;
+  unsigned long t0 = millis();
+  while(millis() - t0 < timeout) {
+    while(_client.available()) {
+      char c = _client.read();
+      if(!in) {
+        if(c == '{') {
+          in = true;
+          r += c;
+        }
+        continue;
+      }
+      r += c;
+      if(c == '}') return r;
+    }
+  }
+  return r;
+}

--- a/wifiSCPI.h
+++ b/wifiSCPI.h
@@ -1,0 +1,21 @@
+#ifndef WIFI_SCPI_H
+#define WIFI_SCPI_H
+
+#include <WiFiS3.h>
+
+class WifiSCPI {
+public:
+  WifiSCPI();
+  bool begin(const char* ssid, const char* pass, const IPAddress& ip, uint16_t port = 5000);
+  bool connectWiFi(const char* ssid, const char* pass, unsigned long timeout = 30000);
+  bool connectRP(const IPAddress& ip, uint16_t port = 5000);
+  void scpi(const String& s);
+  String scpiLine(const String& s, unsigned long timeout = 3000);
+  String scpiBlock(const String& s, unsigned long timeout = 10000);
+  void scpiFlush();
+  bool connected() { return _client.connected(); }
+private:
+  WiFiClient _client;
+};
+
+#endif


### PR DESCRIPTION
## Summary
- Retry WiFi and SCPI connections inside `WifiSCPI::begin` until successful
- Simplify `AcquireNowWifi` sketch to use `WifiSCPI` helper

## Testing
- `arduino-cli compile AcquireNowWifi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a46c751e1c8325917540d4516d6670