### PR TITLE
Add connection retry logic for Red Pitaya WiFi sketches

### DIFF
--- a/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
+++ b/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
@@ -1,29 +1,14 @@
 /* UNO R4 WiFi → Red Pitaya (SCPI)
    acquire_trigger_now: force trigger and read CH1 (ASCII/VOLTS)
 */
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"
 
 IPAddress RP_IP(192,168,0,17);
 const uint16_t RP_PORT = 5000;
 
-WiFiClient client;
+WifiSCPI rp;
 
-/* --- helpers --- */
-void scpiFlush(){ while(client.available()) (void)client.read(); }
-inline void scpi(const String& s){ client.print(s); client.print("\r\n"); }
-String scpiLine(const String& s, unsigned long to=3000){
-  scpiFlush(); scpi(s); String r; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(c=='\n'){ if(r.endsWith("\r")) r.remove(r.length()-1); return r; } r+=c; }
-  return r;
-}
-String scpiBlock(const String& s, unsigned long to=8000){
-  scpiFlush(); scpi(s); String r; bool in=false; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(!in){ if(c=='{'){ in=true; r+=c; } continue; } r+=c; if(c=='}') return r; }
-  return r;
-}
 void printFirst(const String& blk, uint8_t n=12){
   int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
   String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
@@ -31,32 +16,26 @@ void printFirst(const String& blk, uint8_t n=12){
     if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
 }
 
-/* --- connect --- */
-bool connectWiFi(unsigned long to=30000){
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0=millis(); while(WiFi.status()!=WL_CONNECTED && millis()-t0<to) delay(250);
-  if(WiFi.status()!=WL_CONNECTED) return false;
-  unsigned long t1=millis(); while(WiFi.localIP()==IPAddress(0,0,0,0)&&millis()-t1<3000) delay(50);
-  return true;
-}
-bool connectRP(){ if(client.connected()) return true; client.stop(); return client.connect(RP_IP, RP_PORT); }
-
-/* --- Arduino --- */
 void setup(){
   Serial.begin(115200); delay(200);
-  connectWiFi(); connectRP();
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
-  scpi("ACQ:RST");
-  scpi("ACQ:DEC:Factor 128");
-  scpi("ACQ:DATA:FORMAT VOLTS");
-  scpi("ACQ:DATA:UNITS ASCII");
-  scpi("ACQ:TRig:DLY 0");
-  scpi("ACQ:START");
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 128");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
   delay(300);
-  scpi("ACQ:TRig NOW");
+  rp.scpi("ACQ:TRig NOW");
 
-  while(scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
-  printFirst(scpiBlock("ACQ:SOUR1:DATA?"));
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
   Serial.println("Done.");
 }
+
 void loop(){ }
+

--- a/AcquiireWifi/AcquiireWifi.ino
+++ b/AcquiireWifi/AcquiireWifi.ino
@@ -1,10 +1,8 @@
 /* UNO R4 WiFi → Red Pitaya: generate a sine on OUT1 (SCPI)
-   - WiFiS3 networking (UNO R4 WiFi)
-   - SCPI TCP port 5000
-   - Sends: GEN:RST; SOUR1:FUNC SINE; FREQ/AMP/OFFS; OUTPUT1 ON; TRIG INT
+   Sends: GEN:RST; SOUR1:FUNC SINE; FREQ/AMP/OFFS; OUTPUT1 ON; TRIG INT
 */
 
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
 
 // ---------- User config ----------
@@ -17,53 +15,27 @@ const float SINE_AMPL_V  = 1.0;    // amplitude (volts)
 const float SINE_OFFS_V  = 0.0;    // DC offset (volts)
 // ---------------------------------
 
-WiFiClient client;
-
-bool connectWiFi(unsigned long timeoutMs = 30000) {
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0 = millis();
-  while (WiFi.status() != WL_CONNECTED && (millis() - t0) < timeoutMs) delay(250);
-  if (WiFi.status() != WL_CONNECTED) return false;
-  // Ensure not 0.0.0.0
-  unsigned long t1 = millis();
-  while (WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
-  return true;
-}
-
-bool connectRP() {
-  if (client.connected()) return true;
-  client.stop();
-  return client.connect(RP_IP, RP_PORT);
-}
-
-inline void scpiSend(const String& s) {
-  if (!client.connected()) return;
-  client.print(s);
-  client.print("\r\n"); // CRLF is safest
-}
+WifiSCPI rp;
 
 void genSineOut1(float freq_hz, float ampl_v, float offs_v) {
-  scpiSend("GEN:RST");
-  scpiSend("SOUR1:FUNC SINE");
-  scpiSend(String("SOUR1:FREQ:FIX ") + String(freq_hz, 6));
-  scpiSend(String("SOUR1:VOLT ")     + String(ampl_v, 6));
-  scpiSend(String("SOUR1:VOLT:OFFS ")+ String(offs_v, 6));
-  scpiSend("SOUR1:TRig:SOUR INT");
-  scpiSend("OUTPUT1:STATE ON");
-  scpiSend("SOUR1:TRig:INT");
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(freq_hz, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(ampl_v, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(offs_v, 6));
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:INT");
 }
 
 void setup() {
   Serial.begin(115200);
   delay(150);
 
-  Serial.print("WiFi → "); 
-  if (!connectWiFi()) { Serial.println("FAIL"); while (true) delay(1000); }
-  Serial.print("OK, IP="); Serial.println(WiFi.localIP());
-
-  Serial.print("Connecting to RP "); Serial.print(RP_IP); Serial.print(":"); Serial.println(RP_PORT);
-  if (!connectRP()) { Serial.println("TCP connect failed"); while (true) delay(1000); }
-  Serial.println("TCP connected");
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
   // Generate sine on OUT1
   genSineOut1(SINE_FREQ_HZ, SINE_AMPL_V, SINE_OFFS_V);
@@ -72,14 +44,14 @@ void setup() {
 
 void loop() {
   // Keep connection alive (optional)
-  if (WiFi.status() != WL_CONNECTED) connectWiFi();
-  if (!client.connected()) connectRP();
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) rp.connectRP(RP_IP, RP_PORT);
   delay(500);
 }
 
-/* Optional helper to stop output (call once if you want to turn it off)
+// Optional helper to stop output (call once if you want to turn it off)
 void stopOutput1() {
-  scpiSend("OUTPUT1:STATE OFF");
-  // or: scpiSend("GEN:RST");
+  rp.scpi("OUTPUT1:STATE OFF");
+  // or: rp.scpi("GEN:RST");
 }
-*/
+

--- a/AcquireNowRawWifi/AcquireNowRawWifi.ino
+++ b/AcquireNowRawWifi/AcquireNowRawWifi.ino
@@ -1,29 +1,15 @@
 /* UNO R4 WiFi → Red Pitaya (SCPI)
    dma/acquire_dma_trigger_now: set AXI DMA, trigger NOW, read 1024 samples near trig (ASCII)
 */
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"
 
 IPAddress RP_IP(192,168,0,17);
 const uint16_t RP_PORT = 5000;
 
-WiFiClient client;
+WifiSCPI rp;
 
 /* helpers */
-void scpiFlush(){ while(client.available()) (void)client.read(); }
-inline void scpi(const String& s){ client.print(s); client.print("\r\n"); }
-String scpiLine(const String& s, unsigned long to=3000){
-  scpiFlush(); scpi(s); String r; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(c=='\n'){ if(r.endsWith("\r")) r.remove(r.length()-1); return r; } r+=c; }
-  return r;
-}
-String scpiBlock(const String& s, unsigned long to=10000){
-  scpiFlush(); scpi(s); String r; bool in=false; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(!in){ if(c=='{'){ in=true; r+=c; } continue; } r+=c; if(c=='}') return r; }
-  return r;
-}
 void printFirst(const String& blk, uint8_t n=12){
   int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
   String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First DMA samples:"));
@@ -31,45 +17,39 @@ void printFirst(const String& blk, uint8_t n=12){
     if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
 }
 
-/* connect */
-bool connectWiFi(unsigned long to=30000){
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0=millis(); while(WiFi.status()!=WL_CONNECTED && millis()-t0<to) delay(250);
-  if(WiFi.status()!=WL_CONNECTED) return false;
-  unsigned long t1=millis(); while(WiFi.localIP()==IPAddress(0,0,0,0)&&millis()-t1<3000) delay(50);
-  return true;
-}
-bool connectRP(){ if(client.connected()) return true; client.stop(); return client.connect(RP_IP, RP_PORT); }
-
 void setup(){
   Serial.begin(115200); delay(200);
-  connectWiFi(); connectRP();
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
-  // Query AXI region (optional info)
-  uint32_t axiStart = scpiLine("ACQ:AXI:START?").toInt();
-  uint32_t axiSize  = scpiLine("ACQ:AXI:SIZE?").toInt();
+  uint32_t axiStart = rp.scpiLine("ACQ:AXI:START?").toInt();
+  uint32_t axiSize  = rp.scpiLine("ACQ:AXI:SIZE?").toInt();
   (void)axiStart; (void)axiSize;
 
-  scpi("ACQ:RST");
-  scpi("ACQ:AXI:DEC 1");
-  scpi("ACQ:AXI:DATA:UNITS VOLTS");
-  scpi("ACQ:DATA:FORMAT ASCII");
-  scpi(String("ACQ:AXI:SOUR1:SET:Buffer ")+axiStart+","+axiSize);
-  scpi("ACQ:AXI:SOUR1:ENable ON");
-  scpi("ACQ:AXI:SOUR1:Trig:Dly 0");
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:AXI:DEC 1");
+  rp.scpi("ACQ:AXI:DATA:UNITS VOLTS");
+  rp.scpi("ACQ:DATA:FORMAT ASCII");
+  rp.scpi(String("ACQ:AXI:SOUR1:SET:Buffer ")+axiStart+","+axiSize);
+  rp.scpi("ACQ:AXI:SOUR1:ENable ON");
+  rp.scpi("ACQ:AXI:SOUR1:Trig:Dly 0");
 
-  scpi("ACQ:START");
-  scpi("ACQ:TRig NOW");
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig NOW");
 
-  while(scpiLine("ACQ:TRig:STAT?")!="TD") delay(10);
-  while(scpiLine("ACQ:AXI:SOUR1:TRIG:FILL?")!="1") delay(10);
+  while(rp.scpiLine("ACQ:TRig:STAT?")!="TD") delay(10);
+  while(rp.scpiLine("ACQ:AXI:SOUR1:TRIG:FILL?")!="1") delay(10);
 
-  uint32_t pos = scpiLine("ACQ:AXI:SOUR1:Trig:Pos?").toInt();
+  uint32_t pos = rp.scpiLine("ACQ:AXI:SOUR1:Trig:Pos?").toInt();
   String cmd = String("ACQ:AXI:SOUR1:DATA:Start:N? ")+pos+",1024";
-  printFirst(scpiBlock(cmd));
+  printFirst(rp.scpiBlock(cmd));
 
-  scpi("ACQ:STOP");
-  scpi("ACQ:AXI:SOUR1:ENable OFF");
+  rp.scpi("ACQ:STOP");
+  rp.scpi("ACQ:AXI:SOUR1:ENable OFF");
   Serial.println("Done.");
 }
+
 void loop(){ }
+

--- a/AcquireNowWifi/AcquireNowWifi.ino
+++ b/AcquireNowWifi/AcquireNowWifi.ino
@@ -1,60 +1,48 @@
 /* UNO R4 WiFi → Red Pitaya (SCPI)
    acquire_full_buffer_raw: force trigger and read full buffer as RAW ASCII codes
 */
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"
 
 IPAddress RP_IP(192,168,0,17);
 const uint16_t RP_PORT = 5000;
 
-WiFiClient client;
+WifiSCPI rp;
 
-/* helpers */
-void scpiFlush(){ while(client.available()) (void)client.read(); }
-inline void scpi(const String& s){ client.print(s); client.print("\r\n"); }
-String scpiLine(const String& s, unsigned long to=3000){
-  scpiFlush(); scpi(s); String r; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(c=='\n'){ if(r.endsWith("\r")) r.remove(r.length()-1); return r; } r+=c; }
-  return r;
-}
-String scpiBlock(const String& s, unsigned long to=10000){
-  scpiFlush(); scpi(s); String r; bool in=false; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(!in){ if(c=='{'){ in=true; r+=c; } continue; } r+=c; if(c=='}') return r; }
-  return r;
-}
 void printFirst(const String& blk, uint8_t n=12){
-  int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
-  String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First RAW samples:"));
-  while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
-    if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
+  int l=blk.indexOf('{'), r=blk.lastIndexOf('}');
+  if(l<0||r<=l){ Serial.println(blk); return; }
+  String b=blk.substring(l+1,r);
+  int st=0,c=0;
+  Serial.println(F("First RAW samples:"));
+  while(c<n){
+    int k=b.indexOf(',',st);
+    String t=(k==-1)?b.substring(st):b.substring(st,k);
+    t.trim();
+    if(t.length()){ Serial.println(t); c++; }
+    if(k==-1) break;
+    st=k+1;
+  }
 }
-bool connectWiFi(unsigned long to=30000){
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0=millis(); while(WiFi.status()!=WL_CONNECTED && millis()-t0<to) delay(250);
-  if(WiFi.status()!=WL_CONNECTED) return false;
-  unsigned long t1=millis(); while(WiFi.localIP()==IPAddress(0,0,0,0)&&millis()-t1<3000) delay(50);
-  return true;
-}
-bool connectRP(){ if(client.connected()) return true; client.stop(); return client.connect(RP_IP, RP_PORT); }
 
 void setup(){
-  Serial.begin(115200); delay(200);
-  connectWiFi(); connectRP();
+  Serial.begin(115200);
+  delay(200);
+  rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT);
 
-  scpi("ACQ:RST");
-  scpi("ACQ:DEC:Factor 1");
-  scpi("ACQ:DATA:FORMAT ASCII");
-  scpi("ACQ:DATA:UNITS RAW");   // ADC codes
-  scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT ASCII");
+  rp.scpi("ACQ:DATA:UNITS RAW");   // ADC codes
+  rp.scpi("ACQ:TRig:DLY 0");
 
-  scpi("ACQ:START");
+  rp.scpi("ACQ:START");
   delay(300);
-  scpi("ACQ:TRig NOW");
+  rp.scpi("ACQ:TRig NOW");
 
-  while(scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
-  printFirst(scpiBlock("ACQ:SOUR1:DATA?"));
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
   Serial.println("Done.");
 }
-void loop(){ }
+
+void loop(){}

--- a/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
+++ b/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
@@ -4,71 +4,53 @@
    - arm acquisition on AWG trigger (AWG_PE)
    - fire generator INT trigger to produce the edge
 */
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"
 
 IPAddress RP_IP(192,168,0,17);
 const uint16_t RP_PORT = 5000;
 
-WiFiClient client;
+WifiSCPI rp;
 
-/* helpers */
-void scpiFlush(){ while(client.available()) (void)client.read(); }
-inline void scpi(const String& s){ client.print(s); client.print("\r\n"); }
-String scpiLine(const String& s, unsigned long to=3000){
-  scpiFlush(); scpi(s); String r; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(c=='\n'){ if(r.endsWith("\r")) r.remove(r.length()-1); return r; } r+=c; }
-  return r;
-}
-String scpiBlock(const String& s, unsigned long to=8000){
-  scpiFlush(); scpi(s); String r; bool in=false; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(!in){ if(c=='{'){ in=true; r+=c; } continue; } r+=c; if(c=='}') return r; }
-  return r;
-}
 void printFirst(const String& blk, uint8_t n=12){
   int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
   String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
   while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
     if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
 }
-bool connectWiFi(unsigned long to=30000){
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0=millis(); while(WiFi.status()!=WL_CONNECTED && millis()-t0<to) delay(250);
-  if(WiFi.status()!=WL_CONNECTED) return false;
-  unsigned long t1=millis(); while(WiFi.localIP()==IPAddress(0,0,0,0)&&millis()-t1<3000) delay(50);
-  return true;
-}
-bool connectRP(){ if(client.connected()) return true; client.stop(); return client.connect(RP_IP, RP_PORT); }
 
 void setup(){
   Serial.begin(115200); delay(200);
-  connectWiFi(); connectRP();
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
   // Generator: small sine on OUT1
-  scpi("GEN:RST");
-  scpi("SOUR1:FUNC SINE");
-  scpi("SOUR1:FREQ:FIX 10000");
-  scpi("SOUR1:VOLT 0.5");
-  scpi("SOUR1:VOLT:OFFS 0");
-  scpi("OUTPUT1:STATE ON");
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi("SOUR1:FREQ:FIX 10000");
+  rp.scpi("SOUR1:VOLT 0.5");
+  rp.scpi("SOUR1:VOLT:OFFS 0");
+  rp.scpi("OUTPUT1:STATE ON");
 
   // Acquisition waiting for AWG trigger
-  scpi("ACQ:RST");
-  scpi("ACQ:DEC:Factor 1");
-  scpi("ACQ:DATA:FORMAT VOLTS");
-  scpi("ACQ:DATA:UNITS ASCII");
-  scpi("ACQ:TRig:DLY 0");
-  scpi("ACQ:START");
-  scpi("ACQ:TRig AWG_PE");
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig AWG_PE");
 
   // Fire AWG INT trigger
-  scpi("SOUR1:TRig:SOUR INT");
-  scpi("SOUR1:TRig:INT");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
 
-  while(scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
-  printFirst(scpiBlock("ACQ:SOUR1:DATA?"));
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
   Serial.println("Done.");
 }
+
 void loop(){ }
+

--- a/AnalogReadWifi/AnalogReadWifi.ino
+++ b/AnalogReadWifi/AnalogReadWifi.ino
@@ -1,143 +1,77 @@
 /*  UNO R4 WiFi → Red Pitaya (SCPI)
     - OUT1 arbitrary waveform = sum of 3 sines
     - Fast, chunked upload (default 2048 points)
-    - No acquisition, no LEDs — just ARB gen
 */
 
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include <math.h>
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"
 
-/************ User Config ************/
-// Red Pitaya SCPI server
 IPAddress RP_IP(192, 168, 0, 17);
 const uint16_t RP_PORT = 5000;
 
-// ARB buffer size (use 2048 for speed; 16384 is the full period size)
 int   ARB_NPTS     = 2048;
+float F0_HZ        = 1000.0;
+float AMP1 = 1.0f, AMP2 = 0.6f, AMP3 = 0.3f;
+int   K1 = 1, K2 = 2, K3 = 5;
+float P1 = 0.0f, P2 = 0.0f, P3 = 0.0f;
+float ARB_AMPL_V   = 1.0f;
+float ARB_OFFS_V   = 0.0f;
 
-// Base output frequency (Hz). The three tones will be
-// k1*f0, k2*f0, k3*f0 to make a seamless periodic waveform.
-float F0_HZ        = 1000.0;   // "fundamental" frequency
+WifiSCPI rp;
 
-// Amplitudes of the 3 sines (renamed to avoid conflict with A1/A2/A3 pin names)
-float AMP1 = 1.0f,  AMP2 = 0.6f,  AMP3 = 0.3f;
-
-// Harmonic bins (integers). Output tones = k*F0_HZ.
-int   K1 = 1,       K2 = 2,       K3 = 5;
-
-// Optional phases (radians)
-float P1 = 0.0f,    P2 = 0.0f,    P3 = 0.0f;
-
-// Analog output settings
-float ARB_AMPL_V   = 1.0f;     // amplitude (Volts)
-float ARB_OFFS_V   = 0.0f;     // DC offset (Volts)
-/************************************/
-
-WiFiClient client;
-
-/* ---------- SCPI helpers ---------- */
-void scpiFlush() { while (client.available()) (void)client.read(); }
-
-void scpiSend(const String& s) {
-  if (!client.connected()) return;
-  client.print(s);
-  client.print("\r\n");   // CRLF is safest
-}
-
-/* ---------- WiFi / RP connect ---------- */
-bool connectWiFi(unsigned long timeoutMs = 30000) {
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0 = millis();
-  while (WiFi.status() != WL_CONNECTED && (millis() - t0) < timeoutMs) delay(250);
-  if (WiFi.status() != WL_CONNECTED) return false;
-  // ensure not 0.0.0.0
-  unsigned long t1 = millis();
-  while (WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
-  return true;
-}
-
-bool connectRP() {
-  if (client.connected()) return true;
-  client.stop();
-  return client.connect(RP_IP, RP_PORT);
-}
-
-/* ---------- Waveform: sum of 3 sines, normalized to [-1..+1] ---------- */
 float sum3sines_norm(int i, int N) {
-  // angle step = 2π * i / N (one period fits exactly in N samples)
   float t = 2.0f * (float)M_PI * (float)i / (float)N;
   float x = 0.0f;
   x += AMP1 * sinf(K1 * t + P1);
   x += AMP2 * sinf(K2 * t + P2);
   x += AMP3 * sinf(K3 * t + P3);
-
   float S = fabsf(AMP1) + fabsf(AMP2) + fabsf(AMP3);
-  if (S < 1e-9f) S = 1.0f;   // avoid divide-by-zero
-  x /= S;                    // keep within [-1..+1] conservatively
-  if (x > 1.0f) x = 1.0f;    // hard clamp (rare)
+  if (S < 1e-9f) S = 1.0f;
+  x /= S;
+  if (x > 1.0f) x = 1.0f;
   if (x < -1.0f) x = -1.0f;
   return x;
 }
 
-/* ---------- Upload ARB (chunked), configure, and run ---------- */
 bool uploadSum3SinesOut1(int N) {
-  if (!client.connected()) return false;
-
-  Serial.print("Uploading ARB (N="); Serial.print(N); Serial.print(") ... ");
-
-  scpiSend("GEN:RST");
-  scpiSend("OUTPUT1:STATE OFF");
-  scpiSend("SOUR1:FUNC ARBITRARY");
-
-  // Stream values: SOUR1:TRAC:DATA:DATA v0,v1,...,vN-1
-  client.print("SOUR1:TRAC:DATA:DATA ");
+  if (!rp.connected()) return false;
+  rp.scpi("GEN:RST");
+  rp.scpi("OUTPUT1:STATE OFF");
+  rp.scpi("SOUR1:FUNC ARBITRARY");
+  rp.client().print("SOUR1:TRAC:DATA:DATA ");
   const int chunk = 256;
   for (int i = 0; i < N; ++i) {
-    if (i) client.print(",");
-    client.print(sum3sines_norm(i, N), 6);
-    if ((i % chunk) == 0) Serial.print(".");
+    if (i) rp.client().print(",");
+    rp.client().print(sum3sines_norm(i, N), 6);
   }
-  client.print("\r\n");
-  Serial.println(" done");
-
-  // Frequency scaling: when N < 16384, the device repeats the pattern in the 16k buffer.
-  // Scale so the base tone is exactly F0_HZ.
+  rp.client().print("\r\n");
   float freq_set = F0_HZ * (16384.0f / (float)N);
-
-  client.print("SOUR1:FREQ:FIX ");  client.print(freq_set, 6);     client.print("\r\n");
-  client.print("SOUR1:VOLT ");      client.print(ARB_AMPL_V, 6);   client.print("\r\n");
-  client.print("SOUR1:VOLT:OFFS "); client.print(ARB_OFFS_V, 6);   client.print("\r\n");
-  scpiSend("SOUR1:TRig:SOUR INT");
-  scpiSend("OUTPUT1:STATE ON");
-  scpiSend("SOUR1:TRig:INT");
+  rp.client().print("SOUR1:FREQ:FIX ");  rp.client().print(freq_set, 6);     rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT ");      rp.client().print(ARB_AMPL_V, 6);   rp.client().print("\r\n");
+  rp.client().print("SOUR1:VOLT:OFFS "); rp.client().print(ARB_OFFS_V, 6);   rp.client().print("\r\n");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:INT");
   return true;
 }
 
-/* ---------- Arduino ---------- */
 void setup() {
   Serial.begin(115200);
   delay(150);
-
-  Serial.print("WiFi → ");
-  if (!connectWiFi()) { Serial.println("FAIL"); while (true) delay(1000); }
-  Serial.print("OK, IP="); Serial.println(WiFi.localIP());
-
-  Serial.print("Connecting to RP "); Serial.print(RP_IP); Serial.print(":"); Serial.println(RP_PORT);
-  if (!connectRP()) { Serial.println("TCP connect failed"); while (true) delay(1000); }
-  Serial.println("TCP connected");
-
-  // Upload and start the 3-sine sum on OUT1
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)) {
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
   uploadSum3SinesOut1(ARB_NPTS);
-
   Serial.println("Sum-of-3-sines running on OUT1.");
 }
 
 void loop() {
-  // Keep the link healthy (optional)
-  if (WiFi.status() != WL_CONNECTED) connectWiFi();
-  if (!client.connected()) {
-    if (connectRP()) uploadSum3SinesOut1(ARB_NPTS); // re-arm after reconnect
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(RP_IP, RP_PORT)) uploadSum3SinesOut1(ARB_NPTS);
   }
   delay(500);
 }
+

--- a/BurstSignalWifi/BurstSignalWifi.ino
+++ b/BurstSignalWifi/BurstSignalWifi.ino
@@ -3,7 +3,7 @@
    Uses official commands: SOUR1:FUNC PWM, SOUR1:DCYC <ratio>, FREQ/AMP/OFFS
 */
 
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
 
 // ----- User config -----
@@ -16,52 +16,28 @@ const float AMP_V       = 1.0;     // one-way amplitude (V)
 const float OFFS_V      = 0.0;     // DC offset (V)
 // -----------------------
 
-WiFiClient client;
-
-bool connectWiFi(unsigned long timeoutMs = 30000) {
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0 = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - t0 < timeoutMs) delay(250);
-  if (WiFi.status() != WL_CONNECTED) return false;
-  unsigned long t1 = millis();
-  while (WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
-  return true;
-}
-
-bool connectRP() {
-  if (client.connected()) return true;
-  client.stop();
-  return client.connect(RP_IP, RP_PORT);
-}
-
-inline void scpiSend(const String& s) {
-  if (!client.connected()) return;
-  client.print(s); client.print("\r\n");  // CRLF per SCPI
-}
+WifiSCPI rp;
 
 void startPWM() {
-  scpiSend("GEN:RST");
-  scpiSend("SOUR1:FUNC PWM");                                 // PWM waveform
-  scpiSend(String("SOUR1:FREQ:FIX ") + String(PWM_FREQ_HZ, 6));
-  scpiSend(String("SOUR1:VOLT ")     + String(AMP_V, 6));     // amplitude (V)
-  scpiSend(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V, 6));    // offset (V)
-  scpiSend(String("SOUR1:DCYC ")     + String(PWM_DUTY, 6));  // duty cycle (0..1)
-  scpiSend("OUTPUT1:STATE ON");                                // enable OUT1
-  scpiSend("SOUR1:TRig:SOUR INT");                             // internal trig
-  scpiSend("SOUR1:TRig:INT");                                  // start now
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC PWM");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(PWM_FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(AMP_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V, 6));
+  rp.scpi(String("SOUR1:DCYC ")     + String(PWM_DUTY, 6));
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
 }
 
 void setup() {
   Serial.begin(115200);
   delay(150);
 
-  Serial.print("WiFi → ");
-  if (!connectWiFi()) { Serial.println("FAIL"); while (true) delay(1000); }
-  Serial.print("OK, IP="); Serial.println(WiFi.localIP());
-
-  Serial.print("Connecting to RP "); Serial.print(RP_IP); Serial.print(":"); Serial.println(RP_PORT);
-  if (!connectRP()) { Serial.println("TCP connect failed"); while (true) delay(1000); }
-  Serial.println("TCP connected");
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
   startPWM();
   Serial.println("PWM (30% duty) running on OUT1.");
@@ -69,9 +45,10 @@ void setup() {
 
 void loop() {
   // Optional keep-alive / auto-restart
-  if (WiFi.status() != WL_CONNECTED) connectWiFi();
-  if (!client.connected()) {
-    if (connectRP()) startPWM();
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(RP_IP, RP_PORT)) startPWM();
   }
   delay(500);
 }
+

--- a/DMAAcquireWifi/DMAAcquireWifi.ino
+++ b/DMAAcquireWifi/DMAAcquireWifi.ino
@@ -1,74 +1,56 @@
 /* UNO R4 WiFi → Red Pitaya (SCPI)
-   acquire_trigger_from_generator:
+   DMA acquire triggered by generator:
    - start a sine on OUT1
    - arm acquisition on AWG trigger (AWG_PE)
    - fire generator INT trigger to produce the edge
 */
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"
 
 IPAddress RP_IP(192,168,0,17);
 const uint16_t RP_PORT = 5000;
 
-WiFiClient client;
+WifiSCPI rp;
 
-/* helpers */
-void scpiFlush(){ while(client.available()) (void)client.read(); }
-inline void scpi(const String& s){ client.print(s); client.print("\r\n"); }
-String scpiLine(const String& s, unsigned long to=3000){
-  scpiFlush(); scpi(s); String r; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(c=='\n'){ if(r.endsWith("\r")) r.remove(r.length()-1); return r; } r+=c; }
-  return r;
-}
-String scpiBlock(const String& s, unsigned long to=8000){
-  scpiFlush(); scpi(s); String r; bool in=false; unsigned long t0=millis();
-  while(millis()-t0<to) while(client.available()){
-    char c=client.read(); if(!in){ if(c=='{'){ in=true; r+=c; } continue; } r+=c; if(c=='}') return r; }
-  return r;
-}
 void printFirst(const String& blk, uint8_t n=12){
   int l=blk.indexOf('{'), r=blk.lastIndexOf('}'); if(l<0||r<=l){ Serial.println(blk); return; }
   String b=blk.substring(l+1,r); int st=0,c=0; Serial.println(F("First samples:"));
   while(c<n){ int k=b.indexOf(',',st); String t=(k==-1)?b.substring(st):b.substring(st,k); t.trim();
     if(t.length()){ Serial.println(t); c++; } if(k==-1) break; st=k+1; }
 }
-bool connectWiFi(unsigned long to=30000){
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0=millis(); while(WiFi.status()!=WL_CONNECTED && millis()-t0<to) delay(250);
-  if(WiFi.status()!=WL_CONNECTED) return false;
-  unsigned long t1=millis(); while(WiFi.localIP()==IPAddress(0,0,0,0)&&millis()-t1<3000) delay(50);
-  return true;
-}
-bool connectRP(){ if(client.connected()) return true; client.stop(); return client.connect(RP_IP, RP_PORT); }
 
 void setup(){
   Serial.begin(115200); delay(200);
-  connectWiFi(); connectRP();
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
   // Generator: small sine on OUT1
-  scpi("GEN:RST");
-  scpi("SOUR1:FUNC SINE");
-  scpi("SOUR1:FREQ:FIX 10000");
-  scpi("SOUR1:VOLT 0.5");
-  scpi("SOUR1:VOLT:OFFS 0");
-  scpi("OUTPUT1:STATE ON");
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi("SOUR1:FREQ:FIX 10000");
+  rp.scpi("SOUR1:VOLT 0.5");
+  rp.scpi("SOUR1:VOLT:OFFS 0");
+  rp.scpi("OUTPUT1:STATE ON");
 
   // Acquisition waiting for AWG trigger
-  scpi("ACQ:RST");
-  scpi("ACQ:DEC:Factor 1");
-  scpi("ACQ:DATA:FORMAT VOLTS");
-  scpi("ACQ:DATA:UNITS ASCII");
-  scpi("ACQ:TRig:DLY 0");
-  scpi("ACQ:START");
-  scpi("ACQ:TRig AWG_PE");
+  rp.scpi("ACQ:RST");
+  rp.scpi("ACQ:DEC:Factor 1");
+  rp.scpi("ACQ:DATA:FORMAT VOLTS");
+  rp.scpi("ACQ:DATA:UNITS ASCII");
+  rp.scpi("ACQ:TRig:DLY 0");
+  rp.scpi("ACQ:START");
+  rp.scpi("ACQ:TRig AWG_PE");
 
   // Fire AWG INT trigger
-  scpi("SOUR1:TRig:SOUR INT");
-  scpi("SOUR1:TRig:INT");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
 
-  while(scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
-  printFirst(scpiBlock("ACQ:SOUR1:DATA?"));
+  while(rp.scpiLine("ACQ:TRig:FILL?")!="1") delay(10);
+  printFirst(rp.scpiBlock("ACQ:SOUR1:DATA?"));
   Serial.println("Done.");
 }
+
 void loop(){ }
+

--- a/GPIOToggleWifi/GPIOToggleWifi.ino
+++ b/GPIOToggleWifi/GPIOToggleWifi.ino
@@ -1,64 +1,12 @@
-#include <WiFiS3.h>
-#include "SCPI_RP.h"
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"  // SECRET_SSID, SECRET_PASS
 
 // ---------- User config ----------
-#define USE_STATIC_IP  1
 IPAddress RP_IP(192, 168, 0, 17);    // Red Pitaya IP
 const uint16_t RP_PORT = 5000;       // SCPI TCP port
-
-#if USE_STATIC_IP
-IPAddress LOCAL_IP(192,168,0,50);
-IPAddress GATEWAY (192,168,0,1);
-IPAddress SUBNET  (255,255,255,0);
-IPAddress DNS     (8,8,8,8);
-#endif
 // ---------------------------------
 
-WiFiClient client;
-scpi_rp::SCPIRedPitaya rp;  // kept to match your pattern
-bool rpReady = false;
-
-// --- connection (same style as yours) ---
-bool connectWiFi(unsigned long timeoutMs = 30000) {
-#if USE_STATIC_IP
-  WiFi.config(LOCAL_IP, GATEWAY, SUBNET, DNS);
-#endif
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0 = millis();
-  while (WiFi.status() != WL_CONNECTED && (millis() - t0) < timeoutMs) delay(250);
-  if (WiFi.status() == WL_CONNECTED) {
-    unsigned long t1 = millis();
-    while (WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
-  }
-  return WiFi.status() == WL_CONNECTED;
-}
-
-bool connectRP() {
-  if (client.connected()) return true;
-  client.stop();
-  if (!client.connect(RP_IP, RP_PORT)) return false;
-  rp.initSocket(&client);        // bind SCPI to this TCP socket (pattern preserved)
-  rpReady = true;
-  return true;
-}
-
-// --- tiny SCPI helpers on your client socket ---
-void scpiSend(const String& s) { if (client.connected()) { client.print(s); client.print("\r\n"); } }
-String scpiQueryLine(const String& s, unsigned long to=2000) {
-  if (!client.connected()) return "";
-  while (client.available()) (void)client.read();       // flush
-  client.print(s); client.print("\r\n");
-  String r; unsigned long t0=millis();
-  while (millis()-t0<to) {
-    while (client.available()) {
-      char c=client.read();
-      if (c=='\n') { if (r.endsWith("\r")) r.remove(r.length()-1); return r; }
-      r+=c;
-    }
-  }
-  return r;
-}
+WifiSCPI rp;
 
 // --- GPIO pins ---
 const char* OUT_PIN = "DIO0_P";
@@ -68,34 +16,35 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  connectWiFi();
-  connectRP();
-
-  if (client.connected()) {
-    scpiSend(String("DIG:PIN:DIR OUT,") + OUT_PIN);
-    scpiSend(String("DIG:PIN:DIR IN,")  + IN_PIN);
-
-    Serial.print(OUT_PIN); Serial.print(" dir="); Serial.println(scpiQueryLine(String("DIG:PIN:DIR? ")+OUT_PIN));
-    Serial.print(IN_PIN);  Serial.print(" dir="); Serial.println(scpiQueryLine(String("DIG:PIN:DIR? ")+IN_PIN));
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
   }
+
+  rp.scpi(String("DIG:PIN:DIR OUT,") + OUT_PIN);
+  rp.scpi(String("DIG:PIN:DIR IN,")  + IN_PIN);
+
+  Serial.print(OUT_PIN); Serial.print(" dir="); Serial.println(rp.scpiLine(String("DIG:PIN:DIR? ")+OUT_PIN));
+  Serial.print(IN_PIN);  Serial.print(" dir="); Serial.println(rp.scpiLine(String("DIG:PIN:DIR? ")+IN_PIN));
 }
 
 void loop() {
-  if (WiFi.status() != WL_CONNECTED) connectWiFi();
-  if (!client.connected()) {
-    if (connectRP()) {
-      scpiSend(String("DIG:PIN:DIR OUT,") + OUT_PIN);
-      scpiSend(String("DIG:PIN:DIR IN,")  + IN_PIN);
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(RP_IP, RP_PORT)) {
+      rp.scpi(String("DIG:PIN:DIR OUT,") + OUT_PIN);
+      rp.scpi(String("DIG:PIN:DIR IN,")  + IN_PIN);
     }
   }
-  if (!client.connected()) { delay(200); return; }
+  if (!rp.connected()) { delay(200); return; }
 
   static bool level = false;
-  scpiSend(String("DIG:PIN ") + OUT_PIN + "," + (level ? "1" : "0"));
+  rp.scpi(String("DIG:PIN ") + OUT_PIN + "," + (level ? "1" : "0"));
   level = !level;
 
-  String v = scpiQueryLine(String("DIG:PIN? ") + IN_PIN);
+  String v = rp.scpiLine(String("DIG:PIN? ") + IN_PIN);
   Serial.print(IN_PIN); Serial.print(" = "); Serial.println(v);
 
   delay(200);
 }
+

--- a/GenSineWifi/GenSineWifi.ino
+++ b/GenSineWifi/GenSineWifi.ino
@@ -1,9 +1,8 @@
 /* UNO R4 WiFi → Red Pitaya (SCPI)
    OUT1 sweep using official sweep commands (no manual stepping)
-   Docs: SOUR1:FUNC SWEEP; SOUR1:SWEep:FREQ:START/STOP; ...:TIME; ...:MODE; ...:DIR; ...:STATE
 */
 
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
 
 // ------- User config -------
@@ -11,7 +10,7 @@ IPAddress RP_IP(192, 168, 0, 17);   // your Red Pitaya IP
 const uint16_t RP_PORT = 5000;      // SCPI server port
 
 // Output amplitude/offset
-const float AMP_V  = 1.0;           // one-way amplitude (V), keep |AMP_V|+|OFFS_V| ≤ 1 V
+const float AMP_V  = 1.0;           // one-way amplitude (V)
 const float OFFS_V = 0.0;           // DC offset (V)
 
 // Sweep config
@@ -23,63 +22,34 @@ const bool  PINGPONG    = true;     // true=UP_DOWN, false=NORMAL (up only)
 const bool  REPEAT_INF  = true;     // infinite repetitions (else one-shot)
 // ---------------------------
 
-WiFiClient client;
-
-bool connectWiFi(unsigned long timeoutMs = 30000) {
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0 = millis();
-  while (WiFi.status() != WL_CONNECTED && (millis() - t0) < timeoutMs) delay(250);
-  if (WiFi.status() != WL_CONNECTED) return false;
-  unsigned long t1 = millis();
-  while (WiFi.localIP() == IPAddress(0,0,0,0) && (millis() - t1) < 3000) delay(50);
-  return true;
-}
-bool connectRP() {
-  if (client.connected()) return true;
-  client.stop();
-  return client.connect(RP_IP, RP_PORT);
-}
-inline void scpiSend(const String& s) {
-  if (!client.connected()) return;
-  client.print(s); client.print("\r\n");  // CRLF per SCPI
-}
+WifiSCPI rp;
 
 void startSweep() {
-  // Reset generator and set SWEEP waveform
-  scpiSend("GEN:RST");                                 // stop & defaults
-  scpiSend("SOUR1:FUNC SWEEP");                        // enable sweep waveform  (docs)
-  scpiSend(String("SOUR1:VOLT ") + String(AMP_V, 6));  // amplitude (V)
-  scpiSend(String("SOUR1:VOLT:OFFS ") + String(OFFS_V, 6)); // offset (V)
-
-  // Configure sweep
-  scpiSend(String("SOUR1:SWeep:FREQ:START ") + String(F_START_HZ, 6)); // Hz
-  scpiSend(String("SOUR1:SWeep:FREQ:STOP ")  + String(F_STOP_HZ, 6));  // Hz
-  scpiSend(String("SOUR1:SWeep:TIME ")       + String((long)SWEEP_TIME_US)); // µs
-  scpiSend(String("SOUR1:SWeep:MODE ") + (LOG_SWEEP ? "LOG" : "LINEAR"));     // LINEAR/LOG
-  scpiSend(String("SOUR1:SWeep:DIR ")  + (PINGPONG ? "UP_DOWN" : "NORMAL"));  // direction
-
-  // Repetition: infinite or one-shot
-  if (REPEAT_INF) scpiSend("SOUR1:SWeep:REP:INF ON");  // infinite repeats
-  else            scpiSend("SOUR1:SWeep:REP:INF OFF"); // one pass
-
-  // Enable output & run
-  scpiSend("OUTPUT1:STATE ON");        // enable output driver
-  scpiSend("SOUR1:TRig:SOUR INT");     // internal trigger source
-  scpiSend("SOUR1:TRig:INT");          // start from the beginning
-  scpiSend("SOUR1:SWeep:STATE ON");    // start sweep engine
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SWEEP");
+  rp.scpi(String("SOUR1:VOLT ") + String(AMP_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ") + String(OFFS_V, 6));
+  rp.scpi(String("SOUR1:SWeep:FREQ:START ") + String(F_START_HZ, 6));
+  rp.scpi(String("SOUR1:SWeep:FREQ:STOP ")  + String(F_STOP_HZ, 6));
+  rp.scpi(String("SOUR1:SWeep:TIME ")       + String((long)SWEEP_TIME_US));
+  rp.scpi(String("SOUR1:SWeep:MODE ") + (LOG_SWEEP ? "LOG" : "LINEAR"));
+  rp.scpi(String("SOUR1:SWeep:DIR ")  + (PINGPONG ? "UP_DOWN" : "NORMAL"));
+  if (REPEAT_INF) rp.scpi("SOUR1:SWeep:REP:INF ON");
+  else            rp.scpi("SOUR1:SWeep:REP:INF OFF");
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+  rp.scpi("SOUR1:SWeep:STATE ON");
 }
 
 void setup() {
   Serial.begin(115200);
   delay(150);
 
-  Serial.print("WiFi → ");
-  if (!connectWiFi()) { Serial.println("FAIL"); while (true) delay(1000); }
-  Serial.print("OK, IP="); Serial.println(WiFi.localIP());
-
-  Serial.print("Connecting to RP "); Serial.print(RP_IP); Serial.print(":"); Serial.println(RP_PORT);
-  if (!connectRP()) { Serial.println("TCP connect failed"); while (true) delay(1000); }
-  Serial.println("TCP connected");
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
   startSweep();
   Serial.println("Sweep running on OUT1.");
@@ -87,9 +57,10 @@ void setup() {
 
 void loop() {
   // Optional keep-alive / auto-restart
-  if (WiFi.status() != WL_CONNECTED) connectWiFi();
-  if (!client.connected()) {
-    if (connectRP()) startSweep();
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(RP_IP, RP_PORT)) startSweep();
   }
   delay(500);
 }
+

--- a/LEDsWifi/LEDsWifi.ino
+++ b/LEDsWifi/LEDsWifi.ino
@@ -1,80 +1,45 @@
-#include <WiFiS3.h>
-#include "SCPI_RP.h"
-#include "SCPI_WiFi.h"
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"
 
 // ------- User config -------
-#define USE_STATIC_IP  1
 IPAddress RP_IP(192, 168, 0, 17);
 const uint16_t RP_PORT = 5000;
 
 const float GEN_FREQ_HZ   = 2000.0;
 const float GEN_AMPL_V    = 1.0;
 const float GEN_OFFSET_V  = 0.0;
-
-#if USE_STATIC_IP
-  IPAddress LOCAL_IP(192,168,0,50);
-  IPAddress GATEWAY (192,168,0,1);
-  IPAddress SUBNET  (255,255,255,0);
-  IPAddress DNS     (8,8,8,8);
-#endif
 // ---------------------------
 
-scpi_rp::SCPI_WiFi net;          // << new
-scpi_rp::SCPIRedPitaya rp;
-bool rpReady = false;
+WifiSCPI rp;
 
-// (optional) keep these if you like:
-void scpiSend(const String& s) { net.send(s); }
-String scpiQueryLine(const String& s, unsigned long t=2000) { return net.queryLine(s,t); }
-String scpiQueryAsciiBlock(const String& s, unsigned long t=8000) { return net.queryAsciiBlock(s,t); }
+void startGen() {
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(GEN_FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(GEN_AMPL_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(GEN_OFFSET_V, 6));
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
+}
 
 void setup() {
   Serial.begin(115200);
   delay(150);
 
-  Serial.print("WiFi connecting to "); Serial.println(SECRET_SSID);
-
-  scpi_rp::WiFiConfig cfg;
-#if USE_STATIC_IP
-  cfg.useStaticIP = true;
-  cfg.localIP = LOCAL_IP; cfg.gateway = GATEWAY; cfg.subnet = SUBNET; cfg.dns = DNS;
-#endif
-
-  if (!net.connectWiFi(SECRET_SSID, SECRET_PASS, &cfg)) {
-    Serial.println("❌ WiFi failed");
-    while (true) delay(1000);
-  }
-  Serial.print("✅ WiFi OK, IP = "); Serial.println(net.localIP());
-
-  if (!net.connectRP(RP_IP, RP_PORT)) {
-    Serial.println("❌ TCP connect failed (will retry in loop)");
-  } else {
-    Serial.println("✅ TCP connected");
-    net.bind(rp);         // << bind SCPI to this socket (Stream)
-    rpReady = true;
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
   }
 
-  // ... your LED init, genSineOut1(), and first acquire() as before
+  startGen();
 }
 
 void loop() {
-  // Keep connections alive
-  if (!net.isWiFiUp() || !net.isRPUp()) {
-    scpi_rp::WiFiConfig cfg;
-#if USE_STATIC_IP
-    cfg.useStaticIP = true; cfg.localIP = LOCAL_IP; cfg.gateway = GATEWAY; cfg.subnet = SUBNET; cfg.dns = DNS;
-#endif
-    if (net.ensureConnections(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT, &cfg)) {
-      net.bind(rp);                 // re-bind after reconnect
-      rpReady = true;
-      // optionally re-start generator
-      // genSineOut1(GEN_FREQ_HZ, GEN_AMPL_V, GEN_OFFSET_V);
-    } else {
-      rpReady = false;
-    }
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(RP_IP, RP_PORT)) startGen();
   }
-
-  // ... keep your heartbeat + periodic acquisition exactly as before,
-  // but use net.send/query* helpers (already wired above).
+  delay(500);
 }
+

--- a/PWMWifi/PWMWifi.ino
+++ b/PWMWifi/PWMWifi.ino
@@ -5,7 +5,7 @@
    Uses: SOUR<n>:PHAS, OUTPUT:STATE ON, SOUR:TRig:INT
 */
 
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
 
 // -------- User config --------
@@ -13,67 +13,42 @@ IPAddress RP_IP(192, 168, 0, 17);
 const uint16_t RP_PORT = 5000;
 
 const float FREQ_HZ   = 10000.0;  // both channels
-const float AMP_V     = 1.0;      // one-way amplitude (|AMP|+|OFFS| ≤ 1 V on most models)
+const float AMP_V     = 1.0;      // one-way amplitude
 const float OFFS_V    = 0.0;      // DC offset
-const float PHASE_DEG = 90.0;     // OUT2 phase relative to OUT1 (allowed −360..+360) :contentReference[oaicite:1]{index=1}
+const float PHASE_DEG = 90.0;     // OUT2 phase relative to OUT1
 /* ---------------------------- */
 
-WiFiClient client;
-
-bool connectWiFi(unsigned long timeoutMs = 30000) {
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0 = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - t0 < timeoutMs) delay(250);
-  if (WiFi.status() != WL_CONNECTED) return false;
-  unsigned long t1 = millis();
-  while (WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
-  return true;
-}
-bool connectRP() {
-  if (client.connected()) return true;
-  client.stop();
-  return client.connect(RP_IP, RP_PORT);
-}
-inline void scpiSend(const String& s){
-  if (!client.connected()) return;
-  client.print(s); client.print("\r\n"); // CRLF per SCPI
-}
+WifiSCPI rp;
 
 void startTwoSineWithPhase() {
-  scpiSend("GEN:RST");                         // reset generator (safe defaults) :contentReference[oaicite:2]{index=2}
+  rp.scpi("GEN:RST");
 
   // Configure OUT1
-  scpiSend("SOUR1:FUNC SINE");                 // waveform               :contentReference[oaicite:3]{index=3}
-  scpiSend(String("SOUR1:FREQ:FIX ") + String(FREQ_HZ, 6)); // frequency  :contentReference[oaicite:4]{index=4}
-  scpiSend(String("SOUR1:VOLT ")     + String(AMP_V, 6));   // amplitude  :contentReference[oaicite:5]{index=5}
-  scpiSend(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V, 6));  // offset     :contentReference[oaicite:6]{index=6}
-  scpiSend("SOUR1:PHAS 0");                        // 0° reference       :contentReference[oaicite:7]{index=7}
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(AMP_V, 6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V, 6));
+  rp.scpi("SOUR1:PHAS 0");
 
   // Configure OUT2 (same freq/amp, shifted phase)
-  scpiSend("SOUR2:FUNC SINE");
-  scpiSend(String("SOUR2:FREQ:FIX ") + String(FREQ_HZ, 6));
-  scpiSend(String("SOUR2:VOLT ")     + String(AMP_V, 6));
-  scpiSend(String("SOUR2:VOLT:OFFS ")+ String(OFFS_V, 6));
-  scpiSend(String("SOUR2:PHAS ")     + String(PHASE_DEG, 6)); // phase in degrees
+  rp.scpi("SOUR2:FUNC SINE");
+  rp.scpi(String("SOUR2:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR2:VOLT ")     + String(AMP_V, 6));
+  rp.scpi(String("SOUR2:VOLT:OFFS ")+ String(OFFS_V, 6));
+  rp.scpi(String("SOUR2:PHAS ")     + String(PHASE_DEG, 6));
 
-  // Enable both outputs and start generation in-phase reference
-  scpiSend("OUTPUT:STATE ON");                 // arm both channels      :contentReference[oaicite:8]{index=8}
-  scpiSend("SOUR:TRig:INT");                   // align & start both     :contentReference[oaicite:9]{index=9}
-
-  // (Alternative to the line above: scpiSend("PHAS:ALIGN"); does the same.) :contentReference[oaicite:10]{index=10}
+  rp.scpi("OUTPUT:STATE ON");
+  rp.scpi("SOUR:TRig:INT");
 }
 
 void setup() {
   Serial.begin(115200);
   delay(150);
 
-  Serial.print("WiFi → ");
-  if (!connectWiFi()) { Serial.println("FAIL"); while (true) delay(1000); }
-  Serial.print("OK, IP="); Serial.println(WiFi.localIP());
-
-  Serial.print("Connecting to RP "); Serial.print(RP_IP); Serial.print(":"); Serial.println(RP_PORT);
-  if (!connectRP()) { Serial.println("TCP connect failed"); while (true) delay(1000); }
-  Serial.println("TCP connected");
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
   startTwoSineWithPhase();
   Serial.println("Two-channel sine with phase shift is running.");
@@ -81,9 +56,10 @@ void setup() {
 
 void loop() {
   // Optional keep-alive / auto-restart
-  if (WiFi.status() != WL_CONNECTED) connectWiFi();
-  if (!client.connected()) {
-    if (connectRP()) startTwoSineWithPhase();
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(RP_IP, RP_PORT)) startTwoSineWithPhase();
   }
   delay(500);
 }
+

--- a/SweepGenWifi/SweepGenWifi.ino
+++ b/SweepGenWifi/SweepGenWifi.ino
@@ -15,7 +15,7 @@
      SOUR1:TRig:INT
 */
 
-#include <WiFiS3.h>
+#include "wifiSCPI.h"
 #include "arduino_secrets.h"  // SECRET_SSID, SECRET_PASS
 
 // ---------- User config ----------
@@ -33,58 +33,36 @@ const uint32_t REPETITIONS  = 10;       // number of bursts (65536 == infinite)
 const uint32_t PERIOD_US    = 100000;   // time from start-of-burst to start-of-next (µs)
 // ----------------------------------
 
-WiFiClient client;
-
-bool connectWiFi(unsigned long timeoutMs = 30000) {
-  WiFi.begin(SECRET_SSID, SECRET_PASS);
-  unsigned long t0 = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - t0 < timeoutMs) delay(250);
-  if (WiFi.status() != WL_CONNECTED) return false;
-  unsigned long t1 = millis();
-  while (WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
-  return true;
-}
-bool connectRP() {
-  if (client.connected()) return true;
-  client.stop();
-  return client.connect(RP_IP, RP_PORT);
-}
-inline void scpiSend(const String& s) {
-  if (!client.connected()) return;
-  client.print(s); client.print("\r\n");   // CRLF per SCPI
-}
+WifiSCPI rp;
 
 void startBurst() {
   // Reset & basic sine settings
-  scpiSend("GEN:RST");
-  scpiSend("SOUR1:FUNC SINE");
-  scpiSend(String("SOUR1:FREQ:FIX ") + String(FREQ_HZ, 6));
-  scpiSend(String("SOUR1:VOLT ")     + String(AMP_V,   6));
-  scpiSend(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V,  6));
+  rp.scpi("GEN:RST");
+  rp.scpi("SOUR1:FUNC SINE");
+  rp.scpi(String("SOUR1:FREQ:FIX ") + String(FREQ_HZ, 6));
+  rp.scpi(String("SOUR1:VOLT ")     + String(AMP_V,   6));
+  rp.scpi(String("SOUR1:VOLT:OFFS ")+ String(OFFS_V,  6));
 
   // --- Burst mode (official commands) ---
-  scpiSend("SOUR1:BURS:STAT BURST");                     // enable burst mode
-  scpiSend(String("SOUR1:BURS:NCYC ") + String(NCYCLES));        // cycles per burst
-  scpiSend(String("SOUR1:BURS:NOR ")  + String(REPETITIONS));    // number of bursts (65536 == INF)
-  scpiSend(String("SOUR1:BURS:INT:PER ") + String(PERIOD_US));   // period between burst starts, in µs
+  rp.scpi("SOUR1:BURS:STAT BURST");
+  rp.scpi(String("SOUR1:BURS:NCYC ") + String(NCYCLES));
+  rp.scpi(String("SOUR1:BURS:NOR ")  + String(REPETITIONS));
+  rp.scpi(String("SOUR1:BURS:INT:PER ") + String(PERIOD_US));
 
   // Output + trigger
-  scpiSend("OUTPUT1:STATE ON");        // enable output driver
-  scpiSend("SOUR1:TRig:SOUR INT");     // internal trigger
-  scpiSend("SOUR1:TRig:INT");          // start now
+  rp.scpi("OUTPUT1:STATE ON");
+  rp.scpi("SOUR1:TRig:SOUR INT");
+  rp.scpi("SOUR1:TRig:INT");
 }
 
 void setup() {
   Serial.begin(115200);
   delay(150);
 
-  Serial.print("WiFi → ");
-  if (!connectWiFi()) { Serial.println("FAIL"); while (true) delay(1000); }
-  Serial.print("OK, IP="); Serial.println(WiFi.localIP());
-
-  Serial.print("Connecting to RP "); Serial.print(RP_IP); Serial.print(":"); Serial.println(RP_PORT);
-  if (!connectRP()) { Serial.println("TCP connect failed"); while (true) delay(1000); }
-  Serial.println("TCP connected");
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+    Serial.println(F("Failed to connect"));
+    while(true){}
+  }
 
   startBurst();
   Serial.println("Burst started on OUT1.");
@@ -92,9 +70,10 @@ void setup() {
 
 void loop() {
   // Optional keep-alive
-  if (WiFi.status() != WL_CONNECTED) connectWiFi();
-  if (!client.connected()) {
-    if (connectRP()) startBurst();
+  if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
+  if (!rp.connected()) {
+    if (rp.connectRP(RP_IP, RP_PORT)) startBurst();
   }
   delay(500);
 }
+

--- a/wifiSCPI.cpp
+++ b/wifiSCPI.cpp
@@ -1,0 +1,85 @@
+#include "wifiSCPI.h"
+
+WifiSCPI::WifiSCPI() : _client() {}
+
+bool WifiSCPI::begin(const char* ssid, const char* pass, const IPAddress& ip, uint16_t port){
+  while(!connectWiFi(ssid, pass)) {
+    Serial.println(F("WiFi not ready, retrying..."));
+    delay(1000);
+  }
+  while(!connectRP(ip, port)) {
+    Serial.println(F("SCPI connection failed, retrying..."));
+    delay(1000);
+  }
+  return true;
+}
+
+bool WifiSCPI::connectWiFi(const char* ssid, const char* pass, unsigned long timeout){
+  WiFi.begin(ssid, pass);
+  unsigned long t0 = millis();
+  while(WiFi.status() != WL_CONNECTED && millis() - t0 < timeout) delay(250);
+  if(WiFi.status() != WL_CONNECTED) return false;
+  unsigned long t1 = millis();
+  while(WiFi.localIP() == IPAddress(0,0,0,0) && millis() - t1 < 3000) delay(50);
+  return true;
+}
+
+bool WifiSCPI::connectRP(const IPAddress& ip, uint16_t port){
+  if(_client.connected()) return true;
+  _client.stop();
+  return _client.connect(ip, port);
+}
+
+void WifiSCPI::scpiFlush(){
+  while(_client.available()) (void)_client.read();
+}
+
+void WifiSCPI::scpi(const String& s){
+  _client.print(s);
+  _client.print("\r\n");
+}
+
+String WifiSCPI::scpiLine(const String& s, unsigned long timeout){
+  scpiFlush();
+  scpi(s);
+  String r;
+  unsigned long t0 = millis();
+  while(millis() - t0 < timeout) {
+    while(_client.available()) {
+      char c = _client.read();
+      if(c == '\n') {
+        if(r.endsWith("\r")) r.remove(r.length()-1);
+        return r;
+      }
+      r += c;
+    }
+  }
+  return r;
+}
+
+String WifiSCPI::scpiBlock(const String& s, unsigned long timeout){
+  scpiFlush();
+  scpi(s);
+  String r;
+  bool in = false;
+  unsigned long t0 = millis();
+  while(millis() - t0 < timeout) {
+    while(_client.available()) {
+      char c = _client.read();
+      if(!in) {
+        if(c == '{') {
+          in = true;
+          r += c;
+        }
+        continue;
+      }
+      r += c;
+      if(c == '}') return r;
+    }
+  }
+  return r;
+}
+
+WiFiClient& WifiSCPI::client(){
+  return _client;
+}

--- a/wifiSCPI.h
+++ b/wifiSCPI.h
@@ -1,0 +1,22 @@
+#ifndef WIFI_SCPI_H
+#define WIFI_SCPI_H
+
+#include <WiFiS3.h>
+
+class WifiSCPI {
+public:
+  WifiSCPI();
+  bool begin(const char* ssid, const char* pass, const IPAddress& ip, uint16_t port = 5000);
+  bool connectWiFi(const char* ssid, const char* pass, unsigned long timeout = 30000);
+  bool connectRP(const IPAddress& ip, uint16_t port = 5000);
+  void scpi(const String& s);
+  String scpiLine(const String& s, unsigned long timeout = 3000);
+  String scpiBlock(const String& s, unsigned long timeout = 10000);
+  void scpiFlush();
+  bool connected() { return _client.connected(); }
+  WiFiClient& client() { return _client; }
+private:
+  WiFiClient _client;
+};
+
+#endif


### PR DESCRIPTION
## Summary
- Retry WiFi and SCPI connections inside `WifiSCPI::begin` until successful
- Simplify `AcquireNowWifi` sketch to use `WifiSCPI` helper
- Refactor remaining WiFi examples to use shared `WifiSCPI` connection helper
- Expose underlying `WiFiClient` for streaming arbitrary waveform data

## Testing
- `arduino-cli compile AcquireNowWifi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a46c751e1c8325917540d4516d6670